### PR TITLE
Added controller to handle board

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,4 +66,5 @@ group :test do
   gem "selenium-webdriver"
   gem "rspec"
   gem "rspec-rails"
+  gem "nokogiri"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  nokogiri
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class BoardsController < ApplicationController
+  before_action :set_board, only: [:edit, :update]
+  def index
+  end
+
+  def create
+    board = Board.create(current_player: initial_player)
+    redirect_to edit_board_path(board)
+  end
+
+  def edit
+    @board = Board.find_by(id: params[:id])
+  end
+
+  def update
+    filler = Filler.new(@board)
+    response = filler.perform(params[:board][:position].to_i)
+    if response[:success]
+      @board.update(
+        cells: @board.cells,
+        current_player: response[:next_player],
+        winner: response[:ended] ? @board.current_player : nil
+      )
+    end
+    redirect_to edit_board_path(@board)
+  end
+
+  private
+
+  def initial_player
+    ["X", "O"].sample
+  end
+
+  def set_board
+    @board = Board.find_by(id: params[:id])
+  end
+end

--- a/app/views/boards/edit.html.erb
+++ b/app/views/boards/edit.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: @board, method: :put do |form| %>
+  <div>
+    <% if @board.has_winner? %>
+      <p data-test="winner-message"> <%= @board.winner %> won </p>
+    <% end %>
+    <% if @board.tied? %>
+      <p data-test="tie-message">It is a tie!</p>
+    <% end %>
+    <div data-test="tic-tac-toe-grid">
+      <% @board.cells.chars.each_slice(3) do |cell| %>
+        <%= cell %>
+      <% end %>
+    </div>
+  </div>
+  <% unless @board.tied? || @board.has_winner? %>
+    <div data-test="filler-input">
+      <%= form.text_field :position %>
+      <%= form.submit %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag boards_path, method: :post do %> 
+  <%= button_tag "Start game", data: { test: "start-game" } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  resources :boards
 end

--- a/spec/requests/boards_spec.rb
+++ b/spec/requests/boards_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Board endpoints" do
+  describe "GET /boards" do
+    let(:url) { "/boards" }
+    it "returns an :ok status code" do
+      get url
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders a page to start game" do
+      get url
+      
+      html_response = Nokogiri::HTML(response.body)
+      expect(html_response.css("[data-test='start-game']")).not_to be_empty
+    end
+  end
+
+  describe "POST /boards" do
+    let(:url) { "/boards" }
+
+    it "creates a board record" do
+      expect{ post url }.to change{ Board.count }.by(1)
+    end
+    
+    it "redirects to edit board page" do
+      post url
+      board = Board.last
+
+      expect(response).to redirect_to(edit_board_path(board.id))
+    end
+  end
+
+  describe "PUT /boards/:id" do
+    let(:board) { Board.create(current_player: "X") }
+    let(:params) { { board: { position: 1 } } }
+
+    it "redirects to edit board page" do
+      put board_path(board), params: params
+
+      expect(response).to redirect_to(edit_board_path(board.id))
+    end
+
+    it "changes the current player" do
+      expect { put board_path(board), params: params }.to change {board.reload.current_player }
+    end
+
+    it "stores current player in given position" do
+      put board_path(board), params: params
+
+      expect(board.reload.cells).to eq("X" + " " * 8)
+    end
+
+    context "when current move ends the game" do
+      let(:board) { Board.create(current_player: "X", cells: "XO XO    ") }
+      let(:params) { { board: { position: 7 } } }
+
+      it "sets current player as winner" do
+        put board_path(board), params: params
+
+        expect(board.reload.winner).to eq("X")
+      end
+
+      it "sets current user as blank" do
+        put board_path(board), params: params
+
+        expect(board.reload.current_player).to eq("")
+      end
+    end
+  end
+
+  describe "GET /boards/:id/edit" do
+    let(:board) { Board.create(current_player: "X") }
+
+    it "returns an :ok status" do
+      get edit_board_path(board)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "adds fields to register movement for current player" do
+      get edit_board_path(board)
+
+      html_response = Nokogiri::HTML(response.body)
+      expect(html_response.css("[data-test='filler-input']")).not_to be_empty
+    end
+
+    context "when it is a tie" do
+      let(:board) { Board.create(cells: "XOXOXOOXO") }
+
+      it "does not add fields to register movement for current player" do
+        get edit_board_path(board)
+
+        html_response = Nokogiri::HTML(response.body)
+        expect(html_response.css("[data-test='filler-input']")).to be_empty
+      end
+
+      it "displays tie message" do
+        get edit_board_path(board)
+
+        html_response = Nokogiri::HTML(response.body)
+        expect(html_response.css("[data-test='tie-message']")).not_to be_empty
+      end
+    end
+
+    context "when there is a winner" do
+      let(:board) { Board.create(cells: "XO XO X  ") }
+      it "does not add fields to register movement for current player" do
+        get edit_board_path(board)
+
+        html_response = Nokogiri::HTML(response.body)
+        expect(html_response.css("[data-test='filler-input']")).to be_empty
+      end
+
+      it "displays tie message" do
+        get edit_board_path(board)
+
+        html_response = Nokogiri::HTML(response.body)
+        expect(html_response.css("[data-test='winner-message']")).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Create action generates a new board and redirects to board page

- Board page (edit url) allows user to visualize cells and select a number to place its current symbol

- Board page also adds messages in case of a tie or some player won the game

- Update action updates board, adjusts which player plays next and set the winner when game is ended